### PR TITLE
tabwriter: remove broken FilterHTML

### DIFF
--- a/display.go
+++ b/display.go
@@ -29,7 +29,7 @@ func displayIssues(
 	var err error
 
 	buffer := bytes.NewBuffer(nil)
-	board := tabwriter.NewWriter(buffer, 1, 4, 2, ' ', tabwriter.FilterHTML)
+	board := tabwriter.NewWriter(buffer, 1, 4, 2, ' ', 0)
 
 	templates := map[string]*template.Template{}
 


### PR DESCRIPTION
tabwriter.FilterHTML is not working as intended.

```go
board := tabwriter.NewWriter(os.Stdout, 1, 4, 2, ' ', tabwriter.FilterHTML)

board.Write([]byte("XXX-1000\tdo this & that\n"))
board.Write([]byte("XXX-2000\tdo this\n"))

board.Flush()
```

Outputs:

```
XXX-1000  do this & that
XXX-2000        do this
```